### PR TITLE
fix: disabled org not shown in log

### DIFF
--- a/src/migrationTools/Add-ProjectsToConfig.ps1
+++ b/src/migrationTools/Add-ProjectsToConfig.ps1
@@ -14,10 +14,10 @@ $config = Get-Content $configFile | Out-String | ConvertFrom-Json
 for ($orgNum = 0 ; $orgNum -le $config.organisations.Count - 1 ; $orgNum++) {
     $org = $config.organisations[$orgNum]
     if ($org.enabled -eq $false) {
-        Write-InfoLog "Skipping $($organisation.url)"
+        Write-InfoLog "Skipping $($org.url)"
         continue
     }
-    Write-InfoLog "Processing $($organisation.url)"
+    Write-InfoLog "Processing $($org.url)"
     # Create header with PAT
     $token = $null
     $token = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(":$($org.pat)"))
@@ -34,11 +34,11 @@ for ($orgNum = 0 ; $orgNum -le $config.organisations.Count - 1 ; $orgNum++) {
     Write-DebugLog $projectsURL
     $projects = Invoke-RestMethod -Uri $projectsURL -Method Get -ContentType "application/json" -Headers $header
 
-    Write-InfoLog "Processing $($organisation.url) with $($projects.value.count) projects"
+    Write-InfoLog "Processing $($org.url) with $($projects.value.count) projects"
 
     foreach ($project in $projects.value) {
         Write-DebugLog "$project"
-        $IsThereAlready = $organisation.projects | Where-Object { $_.name -eq $project.name }
+        $IsThereAlready = $org.projects | Where-Object { $_.name -eq $project.name }
         if ($IsThereAlready -ne $null) {
             Write-InfoLog "Skipping {project} as already in list" -PropertyValues $project.name
         }

--- a/src/processFieldMigrator/Generate-ProjectStats.ps1
+++ b/src/processFieldMigrator/Generate-ProjectStats.ps1
@@ -13,7 +13,7 @@ $config = Get-Content "$dataFolder\organisations.json" | Out-String | ConvertFro
 
 foreach ($org in $config.organisations) {
     if ($org.enabled -eq $false) {
-        Write-InfoLog "Skipping $($organisation.url)"
+        Write-InfoLog "Skipping $($org.url)"
         continue
     }
     # Create header with PAT

--- a/src/processFieldMigrator/Install-ReflectedWorkItemID.ps1
+++ b/src/processFieldMigrator/Install-ReflectedWorkItemID.ps1
@@ -9,7 +9,7 @@ $fieldConfig = Get-Content "$dataFolder\ReflectedWorkItemId.json" | Out-String |
 
 foreach ($org in $config.organisations) {
   if ($org.enabled -eq $false) {
-    Write-InfoLog "Skipping $($organisation.url)"
+    Write-InfoLog "Skipping $($org.url)"
     continue
   }
   $token = $null


### PR DESCRIPTION
I have a disabled organization in the `organisations.json` file:
```json
{
    "organisations": [
      {
        "enabled": false,
        "url": "https://dev.azure.com/my-first-org",
        "pat": "<my-first-org-pat>",
        "processMatch": []
      },
      {
        "enabled": true,
        "url": "https://dev.azure.com/my-second-org",
        "pat": "<my-second-org-pat>",
        "processMatch": []
      }
    ]
  }
```

I noticed that when executing for example `Generate-ProjectStats.ps1` that the logging was showing `Skipping` and I was wondering what it was skipping.
So, I went looking and found that it is shown for a disabled organization.

This PR fixes the variable used to show the Skipping part.
For `Generate-ProjectStats.ps1` it was (notice the emptiness after `Skipping`):

![image](https://github.com/nkdAgility/azure-devops-automation-tools/assets/41574930/6f757f55-0a39-4e26-8a5b-d478a27f6621)

And after the fix, it becomes (an organisation URL is shown after `Skipping`):

![image](https://github.com/nkdAgility/azure-devops-automation-tools/assets/41574930/03e7d69c-cd2f-4018-aeb7-7461751f971a)

I only executed `Generate-ProjectStats.ps1` but some other files had this small issue as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected logging when disabled organisations are skipped, ensuring the appropriate organisation URL is shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->